### PR TITLE
Allow optional request headers

### DIFF
--- a/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
+++ b/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
@@ -22,12 +22,13 @@ class Generator : ServiceGenerator {
 
             interfaceMethods += """
                 @Throws(ServiceException::class, CancellationException::class)
-                suspend fun ${kotlinServiceMethodName}(request: $reqType): $respType
+                suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>? = null): $respType
              """.trimIndent()
 
             implementationMethods += """
-                override suspend fun ${kotlinServiceMethodName}(request: $reqType): $respType {
+                override suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>?): $respType {
                     val response: HttpResponse = httpClient.post("${service.file.packageName}.${service.name}/${method.name}") {
+                        requestHeaders?.forEach { headers.append(it.key, it.value) }
                         setBody(request.encodeToByteArray())
                     }
                     return $respType.decodeFromByteArray(response.body())

--- a/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
+++ b/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
@@ -39,7 +39,6 @@ class Generator : ServiceGenerator {
         return listOf(
             interfaceKt(service.file.kotlinPackageName, service.name, filePath, interfaceMethods),
             implementationKt(
-                service.file.packageName,
                 service.file.kotlinPackageName,
                 service.name,
                 filePath,
@@ -65,14 +64,14 @@ class Generator : ServiceGenerator {
     }
 
     private fun interfaceKt(
-        packageName: String?,
+        kotlinPackageName: String?,
         serviceName: String,
         filePath: Path,
         interfaceMethods: MutableList<String>
     ) = ServiceGenerator.Result(
         otherFilePath = filePath.resolveSibling("${serviceName}.kt").toString(),
         code = """
-            package $packageName
+            package $kotlinPackageName
             
             import com.collectiveidea.twirp.ServiceException
             import kotlin.coroutines.cancellation.CancellationException
@@ -84,7 +83,6 @@ class Generator : ServiceGenerator {
     )
 
     private fun implementationKt(
-        packageName: String?,
         kotlinPackageName: String?,
         serviceName: String,
         filePath: Path,


### PR DESCRIPTION
This allows callers to add optional request headers on a per-call basis.

For example, to supply an `HttpHeaders.IfNoneMatch` value for [ETag caching](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) if the Twirp service supports it, like [the `twirp-rails` gem does](https://github.com/collectiveidea/twirp-rails#basic-caching-with-etagsif-none-match-headers). Another optional use might be sending an [`Idempotency-Key` header](https://datatracker.ietf.org/doc/draft-ietf-httpapi-idempotency-key-header/) for idempotent requests.

Example usage of the generated code might look something like:

```kotlin
val eTagHeader = mapOf(HttpHeaders.IfNoneMatch to eTagValue)
val response = exampleService.getCacheableData(EmptyRequest(), eTagHeader)
```

