### PR TITLE
Expose response headers in service result as a Pair

### DIFF
--- a/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
+++ b/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
@@ -22,11 +22,11 @@ class Generator : ServiceGenerator {
 
             interfaceMethods += """
                 @Throws(ServiceException::class, CancellationException::class)
-                suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>? = null): Pair<$respType, Headers>
+                suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Headers? = null): Pair<$respType, Headers>
              """.trimIndent()
 
             implementationMethods += """
-                override suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>?): Pair<$respType, Headers> {
+                override suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Headers?): Pair<$respType, Headers> {
                     val response: HttpResponse = httpClient.post("${service.file.packageName}.${service.name}/${method.name}") {
                         requestHeaders?.forEach { headers.append(it.key, it.value) }
                         setBody(request.encodeToByteArray())

--- a/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
+++ b/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
@@ -22,16 +22,16 @@ class Generator : ServiceGenerator {
 
             interfaceMethods += """
                 @Throws(ServiceException::class, CancellationException::class)
-                suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>? = null): $respType
+                suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>? = null): Pair<$respType, Headers>
              """.trimIndent()
 
             implementationMethods += """
-                override suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>?): $respType {
+                override suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Map<String, String>?): Pair<$respType, Headers> {
                     val response: HttpResponse = httpClient.post("${service.file.packageName}.${service.name}/${method.name}") {
                         requestHeaders?.forEach { headers.append(it.key, it.value) }
                         setBody(request.encodeToByteArray())
                     }
-                    return $respType.decodeFromByteArray(response.body())
+                    return Pair($respType.decodeFromByteArray(response.body()), response.headers)
                 }
             """.trimIndent()
         }
@@ -74,6 +74,7 @@ class Generator : ServiceGenerator {
             package $kotlinPackageName
             
             import com.collectiveidea.twirp.ServiceException
+            import io.ktor.http.Headers
             import kotlin.coroutines.cancellation.CancellationException
             
             interface $serviceName {
@@ -97,6 +98,7 @@ class Generator : ServiceGenerator {
             import io.ktor.client.request.post
             import io.ktor.client.request.setBody
             import io.ktor.client.statement.HttpResponse
+            import io.ktor.http.Headers
             import pbandk.decodeFromByteArray
             import pbandk.encodeToByteArray
             


### PR DESCRIPTION
In creating #2, we allowed for sending arbitrary headers, such an ETag value for `If-None-Match`, or a value for `Idempotency-Key`.

This PR provides a way to read headers from the service result. The only way to capture the returned ETag value is to read the response headers, which was impossible prior to this PR.

There's also a small consistency change. Since we're using the `Headers` type in the result for the response, we change the request type to also be `Headers` to match. This changes the call site a bit since the headers should go through `HeadersBuilder`:

```kotlin
val requestHeaders = eTag?.let { Headers.build { append(HttpHeaders.IfNoneMatch, eTag) } }
```

Or, if sending multiple headers, something like:

```kotlin
val requestHeadersBuilder: HeadersBuilder = HeadersBuilder()
eTag?.let { requestHeadersBuilder.append(HttpHeaders.IfNoneMatch, it) }
// Could add more headers here as necessary
val requestHeaders = requestHeadersBuilder.build()
```

On the response side, use destructuring to get at the pair values:

```kotlin
val (response, responseHeaders) = exampleService.doSomethingOrOther(...)
```

... or, when you don't care about the response headers:

```kotlin
val (response, _) = exampleService.doSomething(...)
```