### PR TITLE
Add a helper to determine if an exception is from a `304 Not Modified` response.

### DIFF
--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ServiceException.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ServiceException.kt
@@ -1,6 +1,13 @@
 package com.collectiveidea.twirp
 
+import io.ktor.client.plugins.RedirectResponseException
 import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
 
-class ServiceException(val error: ErrorResponse, responseException: ResponseException) :
-    RuntimeException(error.msg, responseException)
+class ServiceException(val error: ErrorResponse, val responseException: ResponseException) :
+    RuntimeException(error.msg, responseException) {
+
+    fun isNotModifiedException(): Boolean {
+        return responseException is RedirectResponseException && responseException.response.status == HttpStatusCode.NotModified
+    }
+}


### PR DESCRIPTION
In practice, Ktor will throw a `RedirectResponseException` on a `304 Not Modified` server result. This small helper lets us avoid having to repeat ourselves with a cast and status check when we're trying to determine what happened in our exception handling:

```kotlin
try {
   val (response, responseHeaders) = exampleService.getCacheData(...)
} catch (e: ServiceException) {
  if (e.isNotModifiedException()) {
    // Ignore, local cache is not stale.
  }
}
```

`NotModified` is not one of the [Twirp Error code enums](https://twitchtv.github.io/twirp/docs/spec_v7.html#error-codes), so we're on our own in coming up with a way to handle it. Adding it as an enum makes a little more sense, but this works without creating our own extension of the Twirp spec.