### PR TITLE
Fixup headers append syntax

### DIFF
--- a/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
+++ b/generator/src/main/kotlin/com/collectiveidea/twirp/Generator.kt
@@ -28,7 +28,7 @@ class Generator : ServiceGenerator {
             implementationMethods += """
                 override suspend fun ${kotlinServiceMethodName}(request: $reqType, requestHeaders: Headers?): Pair<$respType, Headers> {
                     val response: HttpResponse = httpClient.post("${service.file.packageName}.${service.name}/${method.name}") {
-                        requestHeaders?.forEach { headers.append(it.key, it.value) }
+                        requestHeaders?.let { headers.appendAll(it) }
                         setBody(request.encodeToByteArray())
                     }
                     return Pair($respType.decodeFromByteArray(response.body()), response.headers)


### PR DESCRIPTION
Fixup syntax error in generator code from 5e394973. Moved a little too fast, and the generator doesn't have tests yet, unfortunately.