### PR TITLE
Enable Explicit API mode and update visibilities inside the runtime library.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Changed
 
- * Bump Kotlin from 1.9.21 to 2.0.20
- * Runtime - Bump kotlinx-serialization dependency from 1.6.0 to 1.7.1
- * Runtime - Bump ktor dependency from 2.3.6 to 2.3.12
- * Runtime - Bump Android Gradle Plugin from 8.1.2 to 8.5.2
- * Runtime - Bump Android Compile SDK to 34
- * Bump PBandK from 0.14.2 to 0.15.0
- * Bump gradle from 8.4 to 8.7
+ * Runtime - Enabled Explicit API mode (see [#11](https://github.com/collectiveidea/twirp-kmm/pull/11)). This
+   might hide some of our internal library helpers from downstream consumers.
+ * Update dependencies
+   * Bump Kotlin from 1.9.21 to 2.0.20
+   * Runtime - Bump kotlinx-serialization dependency from 1.6.0 to 1.7.1
+   * Runtime - Bump ktor dependency from 2.3.6 to 2.3.12
+   * Runtime - Bump Android Gradle Plugin from 8.1.2 to 8.5.2
+   * Runtime - Bump Android Compile SDK to 34
+   * Bump PBandK from 0.14.2 to 0.15.0
+   * Bump gradle from 8.4 to 8.7
 
 ## [0.3.2] - 2023-12-06
 

--- a/runtime/build.gradle.kts
+++ b/runtime/build.gradle.kts
@@ -11,6 +11,8 @@ plugins {
 description = "Runtime for Twirp service generator PBandK plugin for use in Kotlin Multiplatform Mobile projects."
 
 kotlin {
+    explicitApi()
+
     androidTarget {
         publishAllLibraryVariants()
     }

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/ktor/InvalidateBearerTokensDeclaration.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/ktor/InvalidateBearerTokensDeclaration.kt
@@ -8,7 +8,7 @@ import io.ktor.client.plugins.plugin
 // Force the Auth plugin to invoke the `loadTokens` block again.
 // See: https://stackoverflow.com/q/72064782 and https://stackoverflow.com/a/67316630
 // and https://youtrack.jetbrains.com/issue/KTOR-4759/Auth-BearerAuthProvider-caches-result-of-loadToken-until-process-death
-fun HttpClient.invalidateBearerTokens() {
+public fun HttpClient.invalidateBearerTokens() {
     try {
         plugin(Auth)
             .providers

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/ktor/IsJsonHelpers.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/ktor/IsJsonHelpers.kt
@@ -4,6 +4,6 @@ import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 
-fun ContentType.isJson() = match(ContentType.Application.Json)
+internal fun ContentType.isJson(): Boolean = match(ContentType.Application.Json)
 
-fun HttpResponse.isJson() = contentType()?.isJson() == true
+internal fun HttpResponse.isJson(): Boolean = contentType()?.isJson() == true

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
-data class ErrorResponse(
+public data class ErrorResponse(
     val code: ErrorCode = ErrorCode.Unknown,
     val msg: String,
     val meta: Map<
@@ -25,8 +25,8 @@ data class ErrorResponse(
 
 // See: https://github.com/twitchtv/twirp/blob/main/docs/spec_v7.md#error-codes
 @Serializable
-enum class ErrorCode(
-    val statusCode: Int,
+public enum class ErrorCode(
+    public val statusCode: Int,
 ) {
     @SerialName("canceled")
     Canceled(HttpStatusCode.RequestTimeout.value),
@@ -92,7 +92,7 @@ enum class ErrorCode(
 // Serialize
 //
 
-fun Any?.toJsonElement(): JsonElement = when (this) {
+internal fun Any?.toJsonElement(): JsonElement = when (this) {
     is Number -> JsonPrimitive(this)
     is Boolean -> JsonPrimitive(this)
     is String -> JsonPrimitive(this)
@@ -102,9 +102,9 @@ fun Any?.toJsonElement(): JsonElement = when (this) {
     else -> JsonNull
 }
 
-fun Collection<*>.toJsonArray() = JsonArray(map { it.toJsonElement() })
+internal fun Collection<*>.toJsonArray() = JsonArray(map { it.toJsonElement() })
 
-fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }.mapValues { it.value.toJsonElement() })
+internal fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }.mapValues { it.value.toJsonElement() })
 
 //
 // Deserialize
@@ -139,14 +139,14 @@ private fun JsonPrimitive.toAnyValue(): Any? {
     throw Exception("Cannot convert JSON $content to value")
 }
 
-private fun JsonElement.toAnyOrNull(): Any? = when (this) {
+internal fun JsonElement.toAnyOrNull(): Any? = when (this) {
     is JsonNull -> null
     is JsonPrimitive -> toAnyValue()
     is JsonObject -> this.map { it.key to it.value.toAnyOrNull() }.toMap()
     is JsonArray -> this.map { it.toAnyOrNull() }
 }
 
-object AnySerializer : KSerializer<Any?> {
+internal object AnySerializer : KSerializer<Any?> {
     private val delegateSerializer = JsonElement.serializer()
     override val descriptor = delegateSerializer.descriptor
 

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/HttpClientTwirpHelper.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/HttpClientTwirpHelper.kt
@@ -9,7 +9,6 @@ import io.ktor.client.request.accept
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 private val twirpErrorJsonDecoder: Json by lazy {

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/HttpClientTwirpHelper.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/HttpClientTwirpHelper.kt
@@ -22,7 +22,7 @@ private val twirpErrorJsonDecoder: Json by lazy {
  * @param baseUrl The base URL of the root Twirp service, excluding the protobuf service name, and
  *  with a trailing slash: e.g. `https://www.example.com/twirp/`
  */
-fun HttpClientConfig<*>.installTwirp(baseUrl: String) {
+public fun HttpClientConfig<*>.installTwirp(baseUrl: String) {
     expectSuccess = true
 
     defaultRequest {

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ServiceException.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ServiceException.kt
@@ -4,10 +4,10 @@ import io.ktor.client.plugins.RedirectResponseException
 import io.ktor.client.plugins.ResponseException
 import io.ktor.http.HttpStatusCode
 
-class ServiceException(
-    val error: ErrorResponse,
-    val responseException: ResponseException,
+public class ServiceException(
+    public val error: ErrorResponse,
+    public val responseException: ResponseException,
 ) : RuntimeException(error.msg, responseException) {
-    fun isNotModifiedException(): Boolean =
+    public fun isNotModifiedException(): Boolean =
         responseException is RedirectResponseException && responseException.response.status == HttpStatusCode.NotModified
 }


### PR DESCRIPTION
See https://kotlinlang.org/docs/reference/whatsnew14.html#explicit-api-mode-for-library-authors

This requires all types/functions/etc. to have their visibility (`public`/`internal`/`private`) explicitly specified and, if they're public, have their type explicitly specified.

This might affect downstream consumers; some of our internal library functions are now explicitly marked for `internal` consumption only.