### PR TITLE
Specify Java 8 target for the generator .jar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+ * Generator - Ensure generator .jar artifact is built for Java 8. See [#15](https://github.com/collectiveidea/twirp-kmm/pull/15).
+
 ## [0.4.0] - 2024-09-03
 
 ### Added
 
- * Runtime - Add additional targets (`js`, `jvm`, etc) (see [#13](https://github.com/collectiveidea/twirp-kmm/pull/13))
+ * Runtime - Add additional targets (`js`, `jvm`, etc). See [#13](https://github.com/collectiveidea/twirp-kmm/pull/13).
 
 ### Changed
 

--- a/generator/build.gradle.kts
+++ b/generator/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     id("org.jetbrains.kotlin.jvm")
     `maven-publish`
@@ -20,6 +22,15 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlin.test.junit)
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+    compilerOptions.jvmTarget.set(JvmTarget.JVM_1_8)
 }
 
 tasks.jar {


### PR DESCRIPTION
This ensures that we consistently build the generator, rather than it defaulting to the java version of the system building the artifact.

This fixes issues such as:

> Caused by: java.lang.UnsupportedClassVersionError: com/collectiveidea/twirp/Generator has been compiled by a more recent version of the Java Runtime (class file version 66.0), this version of the Java Runtime only recognizes class file versions up to 55.0