### PR TITLE
Dependency updates; Ktor 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+* Update dependencies. See [#17](https://github.com/collectiveidea/twirp-kmp/pull/17)
+    * Bump Kotlin from 2.0.20 to 2.0.21
+    * Runtime - Bump Ktor to 3.0.1
+    * Runtime - Bump kotlinx-serialization to 1.7.3
+    * Bump pbandk to 0.16.0
  * **BREAKING** Rename project from twirp-kmm to twirp-kmp. See [#16](https://github.com/collectiveidea/twirp-kmm/pull/16)
  * Generator - Ensure generator .jar artifact is built for Java 8. See [#15](https://github.com/collectiveidea/twirp-kmm/pull/15).
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ android-gradle-plugin = "8.5.2"
 
 kotlinx-serialization = "1.7.2"
 ktor = "2.3.12"
-pbandk = "0.15.0"
+pbandk = "0.16.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.0.21"
 android-gradle-plugin = "8.5.2"
 
 kotlinx-serialization = "1.7.2"
-ktor = "2.3.12"
+ktor = "3.0.1"
 pbandk = "0.16.0"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.0.21"
 android-gradle-plugin = "8.5.2"
 
-kotlinx-serialization = "1.7.1"
+kotlinx-serialization = "1.7.2"
 ktor = "2.3.12"
 pbandk = "0.15.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.0.21"
 android-gradle-plugin = "8.5.2"
 
-kotlinx-serialization = "1.7.2"
+kotlinx-serialization = "1.7.3"
 ktor = "3.0.1"
 pbandk = "0.16.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.20"
+kotlin = "2.0.21"
 android-gradle-plugin = "8.5.2"
 
 kotlinx-serialization = "1.7.1"

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/ktor/InvalidateBearerTokensDeclaration.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/ktor/InvalidateBearerTokensDeclaration.kt
@@ -1,21 +1,12 @@
 package com.collectiveidea.ktor
 
 import io.ktor.client.HttpClient
-import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.authProvider
 import io.ktor.client.plugins.auth.providers.BearerAuthProvider
-import io.ktor.client.plugins.plugin
 
 // Force the Auth plugin to invoke the `loadTokens` block again.
 // See: https://stackoverflow.com/q/72064782 and https://stackoverflow.com/a/67316630
 // and https://youtrack.jetbrains.com/issue/KTOR-4759/Auth-BearerAuthProvider-caches-result-of-loadToken-until-process-death
 public fun HttpClient.invalidateBearerTokens() {
-    try {
-        plugin(Auth)
-            .providers
-            .filterIsInstance<BearerAuthProvider>()
-            .first()
-            .clearToken()
-    } catch (e: IllegalStateException) {
-        // No-op; plugin not installed
-    }
+    authProvider<BearerAuthProvider>()?.clearToken()
 }

--- a/runtime/src/commonTest/kotlin/com/collectiveidea/twirp/ErrorResponseTest.kt
+++ b/runtime/src/commonTest/kotlin/com/collectiveidea/twirp/ErrorResponseTest.kt
@@ -1,6 +1,5 @@
 package com.collectiveidea.twirp
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
Bump dependencies and upgrade to Ktor 3.

* https://github.com/ktorio/ktor/releases/tag/3.0.0
* https://github.com/ktorio/ktor/releases/tag/3.0.1

For Ktor 3, we update our implementation of `invalidateBearerTokens` helper to use the new [`authProvider`](https://github.com/ktorio/ktor/blob/a3bccae4e48b7e13ecae1e27c31ca9e9c9825ce4/ktor-client/ktor-client-plugins/ktor-client-auth/common/src/io/ktor/client/plugins/auth/Auth.kt#L169). No other changes were necessary.