### PR TITLE
Refactor and cleanup `Any?` json deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-* Update dependencies. See [#17](https://github.com/collectiveidea/twirp-kmp/pull/17)
+ * Runtime - Refactor and cleanup `Any?` JSON deserialization. See [#19](https://github.com/collectiveidea/twirp-kmp/pull/19). 
+ * Update dependencies. See [#17](https://github.com/collectiveidea/twirp-kmp/pull/17).
     * Bump Kotlin from 2.0.20 to 2.0.21
     * Runtime - Bump Ktor to 3.0.1
     * Runtime - Bump kotlinx-serialization to 1.7.3
     * Bump pbandk to 0.16.0
- * **BREAKING** Rename project from twirp-kmm to twirp-kmp. See [#16](https://github.com/collectiveidea/twirp-kmm/pull/16)
+ * **BREAKING** Rename project from twirp-kmm to twirp-kmp. See [#16](https://github.com/collectiveidea/twirp-kmm/pull/16).
  * Generator - Ensure generator .jar artifact is built for Java 8. See [#15](https://github.com/collectiveidea/twirp-kmm/pull/15).
 
 ## [0.4.0] - 2024-09-03

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/serialization/json/AnySerializer.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/serialization/json/AnySerializer.kt
@@ -1,0 +1,82 @@
+package com.collectiveidea.serialization.json
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+// `Any?` does not appear to be supported out of the box in kotlinx-serialization.
+//
+// With a little help from https://github.com/Kotlin/kotlinx.serialization/issues/746 and
+// https://github.com/Kotlin/kotlinx.serialization/issues/296 we can write a custom
+// `KSerializer` to do the work for us.
+
+internal object AnySerializer : KSerializer<Any?> {
+    private val delegateSerializer = JsonElement.serializer()
+    override val descriptor = delegateSerializer.descriptor
+
+    override fun serialize(
+        encoder: Encoder,
+        value: Any?,
+    ) {
+        encoder.encodeSerializableValue(delegateSerializer, value.toJsonElement())
+    }
+
+    override fun deserialize(decoder: Decoder): Any? {
+        val jsonElement = decoder.decodeSerializableValue(delegateSerializer)
+        return jsonElement.toAnyOrNull()
+    }
+}
+
+//
+// Serialize
+//
+
+internal fun Any?.toJsonElement(): JsonElement = when (this) {
+    is Number -> JsonPrimitive(this)
+    is Boolean -> JsonPrimitive(this)
+    is String -> JsonPrimitive(this)
+    is Map<*, *> -> toJsonObject()
+    is Collection<*> -> toJsonArray()
+    is JsonElement -> this
+    else -> JsonNull
+}
+
+internal fun Collection<*>.toJsonArray() = JsonArray(map { it.toJsonElement() })
+
+internal fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }.mapValues { it.value.toJsonElement() })
+
+//
+// Deserialize
+//
+
+private fun JsonPrimitive.toAnyValue(): Any? {
+    val content = this.content
+    if (isString) {
+        return content
+    }
+    if (content.equals("null", ignoreCase = true)) {
+        return null
+    }
+    if (content.equals("true", ignoreCase = true)) {
+        return true
+    }
+    if (content.equals("false", ignoreCase = true)) {
+        return false
+    }
+    return content.toIntOrNull()
+        ?: content.toLongOrNull()
+        ?: content.toDoubleOrNull()
+        ?: throw Exception("Cannot convert JSON $content to value")
+}
+
+internal fun JsonElement.toAnyOrNull(): Any? = when (this) {
+    is JsonNull -> null
+    is JsonPrimitive -> toAnyValue()
+    is JsonObject -> map { it.key to it.value.toAnyOrNull() }.toMap()
+    is JsonArray -> map { it.toAnyOrNull() }
+}

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/serialization/json/AnySerializer.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/serialization/json/AnySerializer.kt
@@ -46,13 +46,20 @@ internal fun Any?.toJsonElement(): JsonElement = when (this) {
     else -> JsonNull
 }
 
-internal fun Collection<*>.toJsonArray() = JsonArray(map { it.toJsonElement() })
+private fun Collection<*>.toJsonArray() = JsonArray(map { it.toJsonElement() })
 
-internal fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }.mapValues { it.value.toJsonElement() })
+private fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }.mapValues { it.value.toJsonElement() })
 
 //
 // Deserialize
 //
+
+internal fun JsonElement.toAnyOrNull(): Any? = when (this) {
+    is JsonNull -> null
+    is JsonPrimitive -> toAnyValue()
+    is JsonObject -> map { it.key to it.value.toAnyOrNull() }.toMap()
+    is JsonArray -> map { it.toAnyOrNull() }
+}
 
 private fun JsonPrimitive.toAnyValue(): Any? {
     val content = this.content
@@ -72,11 +79,4 @@ private fun JsonPrimitive.toAnyValue(): Any? {
         ?: content.toLongOrNull()
         ?: content.toDoubleOrNull()
         ?: throw Exception("Cannot convert JSON $content to value")
-}
-
-internal fun JsonElement.toAnyOrNull(): Any? = when (this) {
-    is JsonNull -> null
-    is JsonPrimitive -> toAnyValue()
-    is JsonObject -> map { it.key to it.value.toAnyOrNull() }.toMap()
-    is JsonArray -> map { it.toAnyOrNull() }
 }

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/serialization/json/AnySerializer.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/serialization/json/AnySerializer.kt
@@ -26,10 +26,7 @@ internal object AnySerializer : KSerializer<Any?> {
         encoder.encodeSerializableValue(delegateSerializer, value.toJsonElement())
     }
 
-    override fun deserialize(decoder: Decoder): Any? {
-        val jsonElement = decoder.decodeSerializableValue(delegateSerializer)
-        return jsonElement.toAnyOrNull()
-    }
+    override fun deserialize(decoder: Decoder): Any? = decoder.decodeSerializableValue(delegateSerializer).toAnyOrNull()
 }
 
 //

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
@@ -9,11 +9,8 @@ import kotlinx.serialization.Serializable
 public data class ErrorResponse(
     val code: ErrorCode = ErrorCode.Unknown,
     val msg: String,
-    val meta: Map<
-        String,
-        @Serializable(with = AnySerializer::class)
-        Any?,
-    >? = null,
+    @Suppress("ktlint:standard:annotation")
+    val meta: Map<String, @Serializable(with = AnySerializer::class) Any?>? = null,
 )
 
 // See: https://github.com/twitchtv/twirp/blob/main/docs/spec_v7.md#error-codes

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
@@ -96,8 +96,8 @@ internal fun Any?.toJsonElement(): JsonElement = when (this) {
     is Number -> JsonPrimitive(this)
     is Boolean -> JsonPrimitive(this)
     is String -> JsonPrimitive(this)
-    is Map<*, *> -> this.toJsonObject()
-    is Collection<*> -> this.toJsonArray()
+    is Map<*, *> -> toJsonObject()
+    is Collection<*> -> toJsonArray()
     is JsonElement -> this
     else -> JsonNull
 }
@@ -112,7 +112,7 @@ internal fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }
 
 private fun JsonPrimitive.toAnyValue(): Any? {
     val content = this.content
-    if (this.isString) {
+    if (isString) {
         return content
     }
     if (content.equals("null", ignoreCase = true)) {
@@ -133,8 +133,8 @@ private fun JsonPrimitive.toAnyValue(): Any? {
 internal fun JsonElement.toAnyOrNull(): Any? = when (this) {
     is JsonNull -> null
     is JsonPrimitive -> toAnyValue()
-    is JsonObject -> this.map { it.key to it.value.toAnyOrNull() }.toMap()
-    is JsonArray -> this.map { it.toAnyOrNull() }
+    is JsonObject -> map { it.key to it.value.toAnyOrNull() }.toMap()
+    is JsonArray -> map { it.toAnyOrNull() }
 }
 
 internal object AnySerializer : KSerializer<Any?> {

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
@@ -1,16 +1,9 @@
 package com.collectiveidea.twirp
 
+import com.collectiveidea.serialization.json.AnySerializer
 import io.ktor.http.HttpStatusCode
-import kotlinx.serialization.KSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.json.JsonArray
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
-import kotlinx.serialization.json.JsonObject
-import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 public data class ErrorResponse(
@@ -81,75 +74,4 @@ public enum class ErrorCode(
 
     @SerialName("dataloss")
     Dataloss(HttpStatusCode.InternalServerError.value),
-}
-
-// `Any?` does not appear to be supported out of the box in kotlinx-serialization. With
-// a little help from https://github.com/Kotlin/kotlinx.serialization/issues/746 and
-// https://github.com/Kotlin/kotlinx.serialization/issues/296 we can write a custom
-// `KSerializer` to do the work for us.
-
-//
-// Serialize
-//
-
-internal fun Any?.toJsonElement(): JsonElement = when (this) {
-    is Number -> JsonPrimitive(this)
-    is Boolean -> JsonPrimitive(this)
-    is String -> JsonPrimitive(this)
-    is Map<*, *> -> toJsonObject()
-    is Collection<*> -> toJsonArray()
-    is JsonElement -> this
-    else -> JsonNull
-}
-
-internal fun Collection<*>.toJsonArray() = JsonArray(map { it.toJsonElement() })
-
-internal fun Map<*, *>.toJsonObject() = JsonObject(mapKeys { it.key.toString() }.mapValues { it.value.toJsonElement() })
-
-//
-// Deserialize
-//
-
-private fun JsonPrimitive.toAnyValue(): Any? {
-    val content = this.content
-    if (isString) {
-        return content
-    }
-    if (content.equals("null", ignoreCase = true)) {
-        return null
-    }
-    if (content.equals("true", ignoreCase = true)) {
-        return true
-    }
-    if (content.equals("false", ignoreCase = true)) {
-        return false
-    }
-    return content.toIntOrNull()
-        ?: content.toLongOrNull()
-        ?: content.toDoubleOrNull()
-        ?: throw Exception("Cannot convert JSON $content to value")
-}
-
-internal fun JsonElement.toAnyOrNull(): Any? = when (this) {
-    is JsonNull -> null
-    is JsonPrimitive -> toAnyValue()
-    is JsonObject -> map { it.key to it.value.toAnyOrNull() }.toMap()
-    is JsonArray -> map { it.toAnyOrNull() }
-}
-
-internal object AnySerializer : KSerializer<Any?> {
-    private val delegateSerializer = JsonElement.serializer()
-    override val descriptor = delegateSerializer.descriptor
-
-    override fun serialize(
-        encoder: Encoder,
-        value: Any?,
-    ) {
-        encoder.encodeSerializableValue(delegateSerializer, value.toJsonElement())
-    }
-
-    override fun deserialize(decoder: Decoder): Any? {
-        val jsonElement = decoder.decodeSerializableValue(delegateSerializer)
-        return jsonElement.toAnyOrNull()
-    }
 }

--- a/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
+++ b/runtime/src/commonMain/kotlin/com/collectiveidea/twirp/ErrorResponse.kt
@@ -124,19 +124,10 @@ private fun JsonPrimitive.toAnyValue(): Any? {
     if (content.equals("false", ignoreCase = true)) {
         return false
     }
-    val intValue = content.toIntOrNull()
-    if (intValue != null) {
-        return intValue
-    }
-    val longValue = content.toLongOrNull()
-    if (longValue != null) {
-        return longValue
-    }
-    val doubleValue = content.toDoubleOrNull()
-    if (doubleValue != null) {
-        return doubleValue
-    }
-    throw Exception("Cannot convert JSON $content to value")
+    return content.toIntOrNull()
+        ?: content.toLongOrNull()
+        ?: content.toDoubleOrNull()
+        ?: throw Exception("Cannot convert JSON $content to value")
 }
 
 internal fun JsonElement.toAnyOrNull(): Any? = when (this) {

--- a/runtime/src/commonTest/kotlin/com/collectiveidea/twirp/ErrorResponseTest.kt
+++ b/runtime/src/commonTest/kotlin/com/collectiveidea/twirp/ErrorResponseTest.kt
@@ -54,28 +54,26 @@ class ErrorResponseTest {
 
         val meta = error.meta
         assertNotNull(meta)
-        assertEquals("a string", meta["key1"])
-        assertEquals(false, meta["key2"])
-        assertEquals(51, meta["key3"])
-
-        val key4Array = meta["key4"] as ArrayList<*>
-        assertEquals(4, key4Array.size)
-        assertEquals(true, key4Array[0])
-        assertEquals(1, key4Array[1])
-        assertEquals("test", key4Array[2])
-        val key4ArrayNestedMap = key4Array[3] as Map<*, *>
-        assertEquals(1, key4ArrayNestedMap.keys.size)
-        assertEquals("yup", key4ArrayNestedMap["nestedKey0"])
-
-        val key5Map = meta["key5"] as Map<*, *>
-        assertEquals("another string", key5Map["nestedKey1"])
-        assertEquals(true, key5Map["nestedKey2"])
-        assertEquals(17, key5Map["nestedKey3"])
-        val key5NestedArray = key5Map["nestedKey4"] as ArrayList<*>
-        assertEquals(2, key5NestedArray.size)
-        assertEquals(9, key5NestedArray[0])
-        assertEquals(null, key5NestedArray[1])
-
-        assertEquals(null, meta["key6"])
+        assertEquals(
+            mapOf(
+                "key1" to "a string",
+                "key2" to false,
+                "key3" to 51,
+                "key4" to listOf(
+                    true,
+                    1,
+                    "test",
+                    mapOf("nestedKey0" to "yup"),
+                ),
+                "key5" to mapOf(
+                    "nestedKey1" to "another string",
+                    "nestedKey2" to true,
+                    "nestedKey3" to 17,
+                    "nestedKey4" to listOf(9, null),
+                ),
+                "key6" to null,
+            ),
+            meta,
+        )
     }
 }

--- a/runtime/src/commonTest/kotlin/com/collectiveidea/twirp/ErrorResponseTest.kt
+++ b/runtime/src/commonTest/kotlin/com/collectiveidea/twirp/ErrorResponseTest.kt
@@ -46,7 +46,9 @@ class ErrorResponseTest {
                     "nestedKey3": 17,
                     "nestedKey4": [9, null]
                 },
-                "key6": null
+                "key6": null,
+                "key7": 12.53,
+                "key8": 4000000000
             }
         }
             """.trimIndent(),
@@ -72,6 +74,8 @@ class ErrorResponseTest {
                     "nestedKey4" to listOf(9, null),
                 ),
                 "key6" to null,
+                "key7" to 12.53,
+                "key8" to 4000000000,
             ),
             meta,
         )


### PR DESCRIPTION
Extracts the generic `AnySerializer` (that our  `ErrorResponse` serializable data class relies on) into its own package and file.

Adds some additional test coverage to ensure doubles and longs in JSON responses are converted properly. (Note that we don't test serialization as it's not relevant to our use case.)